### PR TITLE
Added a grouping for BNF grammar with parenthesis

### DIFF
--- a/Yoakke.Parser.Generator/Ast/BnfAst.Group.cs
+++ b/Yoakke.Parser.Generator/Ast/BnfAst.Group.cs
@@ -1,0 +1,32 @@
+﻿namespace Yoakke.Parser.Generator.Ast
+{
+    partial class BnfAst
+    {
+        /// <summary>
+        /// Represents a grouped sub-rule application that won't be unwrapped when transformed.
+        /// </summary>
+        public class Group : BnfAst
+        {
+            /// <summary>
+            /// The sub-rule that won't be unwrapped when transformed.
+            /// </summary>
+            public readonly BnfAst Subexpr;
+
+            public Group(BnfAst subexpr)
+            {
+                Subexpr = subexpr;
+            }
+
+            public override bool Equals(BnfAst other) => other is Group group
+               && Subexpr.Equals(group.Subexpr);
+            public override int GetHashCode() => Subexpr.GetHashCode();
+
+            public override BnfAst Desugar() => Subexpr is Seq
+                ? new Group(Subexpr.Desugar())
+                : Subexpr.Desugar();
+
+            public override string GetParsedType(RuleSet ruleSet, TokenKindSet tokens) =>
+                Subexpr.GetParsedType(ruleSet, tokens);
+        }
+    }
+}

--- a/Yoakke.Parser.Generator/ParserSourceGenerator.cs
+++ b/Yoakke.Parser.Generator/ParserSourceGenerator.cs
@@ -160,6 +160,7 @@ namespace {namespaceName}
             BnfAst.Seq seq => seq.Elements.All(CheckBnfAst),
             BnfAst.FoldLeft foldl => CheckBnfAst(foldl.First) && CheckBnfAst(foldl.Second),
             BnfAst.Opt opt => CheckBnfAst(opt.Subexpr),
+            BnfAst.Group grp => CheckBnfAst(grp.Subexpr),
             BnfAst.Rep0 rep0 => CheckBnfAst(rep0.Subexpr),
             BnfAst.Rep1 rep1 => CheckBnfAst(rep1.Subexpr),
             BnfAst.Transform tr => CheckBnfAst(tr.Subexpr),
@@ -299,6 +300,13 @@ namespace {namespaceName}
                 var subVar = GenerateBnf(code, rule, opt.Subexpr, lastIndex);
                 code.AppendLine($"if ({subVar}.IsOk) {resultVar} = {TypeNames.ParserBase}.Ok<{parsedType}>({subVar}.Ok.Value, {subVar}.Ok.Offset, {subVar}.Ok.FurthestError);");
                 code.AppendLine($"else {resultVar} = {TypeNames.ParserBase}.Ok(default({parsedType}), {lastIndex}, {subVar}.Error);");
+                break;
+            }
+
+            case BnfAst.Group grp:
+            {
+                var subVar = GenerateBnf(code, rule, grp.Subexpr, lastIndex);
+                code.AppendLine($"{resultVar} = {subVar};");
                 break;
             }
 
@@ -450,6 +458,7 @@ namespace {namespaceName}
                BnfAst.Transform
             or BnfAst.Call 
             or BnfAst.Opt
+            or BnfAst.Group
             or BnfAst.Rep0
             or BnfAst.Rep1
             or BnfAst.Literal => AllocateVarName(),

--- a/Yoakke.Parser.Generator/Syntax/BnfParser.cs
+++ b/Yoakke.Parser.Generator/Syntax/BnfParser.cs
@@ -67,7 +67,7 @@ namespace Yoakke.Parser.Generator.Syntax
             {
                 var sub = ParseAlt();
                 Expect(BnfTokenType.CloseParen);
-                return sub;
+                return new BnfAst.Group(sub);
             }
             if (TryMatch(BnfTokenType.Identifier, out var ident))
             {

--- a/Yoakke.Parser.Tests/PunctuatedTests.cs
+++ b/Yoakke.Parser.Tests/PunctuatedTests.cs
@@ -6,20 +6,24 @@ using Yoakke.Lexer;
 using Yoakke.Lexer.Attributes;
 using Yoakke.Parser.Attributes;
 using IgnoreAttribute = Yoakke.Lexer.Attributes.IgnoreAttribute;
-using Token = Yoakke.Lexer.Token<Yoakke.Parser.Tests.SeparatedTests.TokenType>;
+using Token = Yoakke.Lexer.Token<Yoakke.Parser.Tests.PunctuatedTests.TokenType>;
 
 namespace Yoakke.Parser.Tests
 {
-    [Parser(typeof(SeparatedTests.TokenType))]
+    [Parser(typeof(PunctuatedTests.TokenType))]
     partial class ListParser
     {
         [Rule("any0_no_trailing : Lparen (Identifier (',' Identifier)*)? Rparen")]
         private static List<string> ZeroOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) => 
             elements.Values.Select(t => t.Text).ToList();
+
+        [Rule("any1_no_trailing : Lparen (Identifier (',' Identifier)*) Rparen")]
+        private static List<string> OneOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) =>
+            elements.Values.Select(t => t.Text).ToList();
     }
 
     [TestClass]
-    public class SeparatedTests
+    public class PunctuatedTests
     {
         [Lexer("ListLexer")]
         public enum TokenType
@@ -35,29 +39,48 @@ namespace Yoakke.Parser.Tests
         }
 
         private static List<string> Any0NoTrailing(string source) => new ListParser(new ListLexer(source)).ParseAny0NoTrailing().Ok.Value;
+        private static List<string> Any1NoTrailing(string source) => new ListParser(new ListLexer(source)).ParseAny1NoTrailing().Ok.Value;
 
         [TestMethod]
-        public void TestEmpty()
+        public void Empty0NoTrailing()
         {
             Assert.IsTrue(Any0NoTrailing("()").SequenceEqual(new string[] { }));
         }
 
         [TestMethod]
-        public void TestOne()
+        public void One0NoTrailing()
         {
             Assert.IsTrue(Any0NoTrailing("(a)").SequenceEqual(new string[] { "a" }));
         }
 
         [TestMethod]
-        public void TestTwo()
+        public void Two0NoTrailing()
         {
             Assert.IsTrue(Any0NoTrailing("(a, b)").SequenceEqual(new string[] { "a", "b" }));
         }
 
         [TestMethod]
-        public void TestMany()
+        public void Many0NoTrailing()
         {
             Assert.IsTrue(Any0NoTrailing("(a, b, c, d, e)").SequenceEqual(new string[] { "a", "b", "c", "d", "e" }));
+        }
+
+        [TestMethod]
+        public void One1NoTrailing()
+        {
+            Assert.IsTrue(Any1NoTrailing("(a)").SequenceEqual(new string[] { "a" }));
+        }
+
+        [TestMethod]
+        public void Two1NoTrailing()
+        {
+            Assert.IsTrue(Any1NoTrailing("(a, b)").SequenceEqual(new string[] { "a", "b" }));
+        }
+
+        [TestMethod]
+        public void Many1NoTrailing()
+        {
+            Assert.IsTrue(Any1NoTrailing("(a, b, c, d, e)").SequenceEqual(new string[] { "a", "b", "c", "d", "e" }));
         }
     }
 }

--- a/Yoakke.Parser/ParserBase.cs
+++ b/Yoakke.Parser/ParserBase.cs
@@ -161,7 +161,7 @@ namespace Yoakke.Parser
             if (first.IsOk) return first;
             if (second.IsOk) return second;
             // Both are errors
-            return new ParseResult<T>(ParseError.Unify(first.Error, second.Error));
+            return new ParseResult<T>(ParseError.Unify(first.Error, second.Error)!);
         }
 
         // TODO: Doc


### PR DESCRIPTION
Made parenthesis keep the grouping in BNF rule notation. For now I saw no reason to introduce an explicit operator, parenthesis simply look fine.

Resolves #7.