### PR TITLE
Add option to trim empty lines at edges in diagnostics presenter

### DIFF
--- a/Sources/Core/Yoakke.Reporting/Present/DiagnosticsStyle.cs
+++ b/Sources/Core/Yoakke.Reporting/Present/DiagnosticsStyle.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 Yoakke.
+// Copyright (c) 2021 Yoakke.
 // Licensed under the Apache License, Version 2.0.
 // Source repository: https://github.com/LanguageDev/Yoakke
 
@@ -58,6 +58,12 @@ namespace Yoakke.Reporting.Present
         /// How big of a gap can we connect up between annotated lines.
         /// </summary>
         public int ConnectUpLines { get; set; } = 1;
+
+        /// <summary>
+        /// If <see langword="true"/>, source lines that only contain whitespace at the beginning or end of blocks will not be printed.
+        /// </summary>
+        /// <remarks>
+        public bool TrimEmptySourceLinesAtEdges { get; set; } = true;
 
         public ConsoleColor GetSeverityColor(Severity severity) =>
             this.SeverityColors.TryGetValue(severity, out var col) ? col : this.DefaultColor;

--- a/Sources/Core/Yoakke.Reporting/Present/DiagnosticsStyle.cs
+++ b/Sources/Core/Yoakke.Reporting/Present/DiagnosticsStyle.cs
@@ -62,7 +62,6 @@ namespace Yoakke.Reporting.Present
         /// <summary>
         /// If <see langword="true"/>, source lines that only contain whitespace at the beginning or end of blocks will not be printed.
         /// </summary>
-        /// <remarks>
         public bool TrimEmptySourceLinesAtEdges { get; set; } = true;
 
         public ConsoleColor GetSeverityColor(Severity severity) =>

--- a/Sources/Core/Yoakke.Reporting/Present/TextDiagnosticsPresenter.cs
+++ b/Sources/Core/Yoakke.Reporting/Present/TextDiagnosticsPresenter.cs
@@ -194,6 +194,7 @@ namespace Yoakke.Reporting.Present
             }
 
             // Write a single separator line
+            this.buffer.ForegroundColor = this.Style.DefaultColor;
             this.buffer.WriteLine($"{lineNumberPadding} │");
         }
 

--- a/Sources/Tests/Yoakke.Reporting.Tests/TextPresenterTests.cs
+++ b/Sources/Tests/Yoakke.Reporting.Tests/TextPresenterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 Yoakke.
+// Copyright (c) 2021 Yoakke.
 // Licensed under the Apache License, Version 2.0.
 // Source repository: https://github.com/LanguageDev/Yoakke
 
@@ -225,6 +225,79 @@ last line");
 8 │ some other line
   │      ----- some annotation2
 9 │ last line
+  │
+", result.ToString());
+        }
+
+        [TestMethod]
+        public void EmptyLineTrimming()
+        {
+            var src = new SourceFile(
+                "simple.txt",
+@"
+
+
+error here
+
+context
+
+
+
+");
+            var diag = new Diagnostics()
+                .WithSeverity(Severity.Error)
+                .WithCode("E0001")
+                .WithMessage("Some error message")
+                .WithSourceInfo(Loc(src, line: 3, column: 6, length: 4), Severity.Error, "some annotation");
+            var result = new StringWriter();
+            var renderer = new TextDiagnosticsPresenter(result);
+            renderer.Style.TrimEmptySourceLinesAtEdges = true;
+            renderer.Present(diag);
+            Assert.AreEqual(
+            @"error[E0001]: Some error message
+  ┌─ simple.txt:4:7
+  │
+4 │ error here
+  │       ^^^^ some annotation
+  │
+", result.ToString());
+        }
+
+        [TestMethod]
+        public void EmptyLineTrimmingWithDots()
+        {
+            var src = new SourceFile(
+                "simple.txt",
+@"
+hello
+
+
+
+
+
+bye
+
+
+");
+            var diag = new Diagnostics()
+                .WithSeverity(Severity.Error)
+                .WithCode("E0001")
+                .WithMessage("Some error message")
+                .WithSourceInfo(Loc(src, line: 1, column: 0, length: 5), Severity.Error, "some annotation1")
+                .WithSourceInfo(Loc(src, line: 7, column: 0, length: 3), Severity.Error, "some annotation2");
+            var result = new StringWriter();
+            var renderer = new TextDiagnosticsPresenter(result);
+            renderer.Style.TrimEmptySourceLinesAtEdges = true;
+            renderer.Present(diag);
+            Assert.AreEqual(
+            @"error[E0001]: Some error message
+  ┌─ simple.txt:2:1
+  │
+2 │ hello
+  │ ^^^^^ some annotation1
+  │ ...
+8 │ bye
+  │ ^^^ some annotation2
   │
 ", result.ToString());
         }


### PR DESCRIPTION
Closes #25 

If the new option `TrimEmptySourceLinesAtEdges` of `DiagnosticsStyle` is set to `true`, lines that only contain whitespace at the very beginning or very end of a line primitives block (corresponding to the same source file) will be trimmed consecutively until the first non-empty line.

For example,
```
   ┌─ file1
   |
 1 |
 2 |
 3 | 
 4 | test
     ^^^^ annotation here
 5 | more text
 6 |
 7 |
   |
```
becomes:
```
   ┌─ file1
   |
 4 | test
     ^^^^ annotation here
 5 | more text
   |
```

Additionally, the second commit fixes a very small issue where the last `|` added for padding becomes "contaminated" with the color of the last line. This issue became more evident after implementing the trimming.