### PR TITLE
Fixed newline comparisons in tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ doc
 TestResults
 CoverageResults
 node_modules
-out

--- a/Sources/Examples/Yoakke.Lsp.Server.Sample.VsCodeClient/out/.gitignore
+++ b/Sources/Examples/Yoakke.Lsp.Server.Sample.VsCodeClient/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/Sources/Tests/Yoakke.Reporting.Tests/AssertUtils.cs
+++ b/Sources/Tests/Yoakke.Reporting.Tests/AssertUtils.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Yoakke.
+// Licensed under the Apache License, Version 2.0.
+// Source repository: https://github.com/LanguageDev/Yoakke
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Yoakke.Reporting.Tests
+{
+    /// <summary>
+    /// Assertion helpers.
+    /// </summary>
+    public static class AssertUtils
+    {
+        public static void AreEqualIgnoreNewlineEncoding(string expected, string got) =>
+            Assert.AreEqual(NormalizeNewlines(expected), NormalizeNewlines(got));
+
+        private static string NormalizeNewlines(string s) => s.Replace("\r\n", "\n").Replace('\r', '\n');
+    }
+}

--- a/Sources/Tests/Yoakke.Reporting.Tests/TextPresenterTests.cs
+++ b/Sources/Tests/Yoakke.Reporting.Tests/TextPresenterTests.cs
@@ -33,7 +33,7 @@ some other line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -64,7 +64,7 @@ last line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -98,7 +98,7 @@ last line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -134,7 +134,7 @@ last line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -172,7 +172,7 @@ last line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -212,7 +212,7 @@ last line");
             var result = new StringWriter();
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
                 @"error[E0001]: Some error message
   ┌─ simple.txt:3:11
   │
@@ -253,7 +253,7 @@ context
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Style.TrimEmptySourceLinesAtEdges = true;
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
             @"error[E0001]: Some error message
   ┌─ simple.txt:4:7
   │
@@ -289,7 +289,7 @@ bye
             var renderer = new TextDiagnosticsPresenter(result);
             renderer.Style.TrimEmptySourceLinesAtEdges = true;
             renderer.Present(diag);
-            Assert.AreEqual(
+            AssertUtils.AreEqualIgnoreNewlineEncoding(
             @"error[E0001]: Some error message
   ┌─ simple.txt:2:1
   │


### PR DESCRIPTION
Closes #46, also made sure the `out` folder remains in the VS code project.