### PR TITLE
Add lexer regexes for floating point and real numbers

### DIFF
--- a/Sources/Core/Yoakke.Lexer/Regexes.cs
+++ b/Sources/Core/Yoakke.Lexer/Regexes.cs
@@ -41,7 +41,7 @@ namespace Yoakke.Lexer
         ///
         /// Note that this CANNOT represent all IEEE-754 floating point values, as special values such as infinity or NaN are not supported.
         /// </remarks>
-        /// <seealso cref="IeeeFloatLiteral(string, string)"/>
+        /// <seealso cref="IeeeFloatLiteral"/>
         public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?";
 
         /// <summary>
@@ -53,12 +53,9 @@ namespace Yoakke.Lexer
         /// A leading sign (<c>+</c> or <c>-</c>) may be indicated, but only if the whole part is provided and begins with a number.
         /// Digits may be separated with <c>_</c>, but this symbol may not appear in the first position (<c>1_234.1</c> means <c>1234.1</c>).
         /// Scientific notation is supported by appending <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
+        /// Special cases <c>infinity</c> and <c>NaN</c> are supported, where positive and negative infinity are disambiguated using a leading sign.
         /// </remarks>
-        /// <param name="infinityLiteral">The keyword to represent the infinity value. Positive and negative infinity are disambiguated with a leading sign.</param>
-        /// <param name="nanLiteral">The keyword to represent the NaN (Not a Number) value.</param>
-        /// <returns>A regular expression capable of accepting representations for all values of IEEE-754 floating point numbers with the provided parameters.</returns>
-        public static string IeeeFloatLiteral(string infinityLiteral = "infinity", string nanLiteral = "NaN") =>
-            $"((([0-9]*.)|([+-]?[0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?)|([+-]?{infinityLiteral})|({nanLiteral})";
+        public const string IeeeFloatLiteral = "((([0-9]*.)|([+-]?[0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?)|([+-]?infinity)|(NaN)";
 
         /// <summary>
         /// A single-line string.

--- a/Sources/Core/Yoakke.Lexer/Regexes.cs
+++ b/Sources/Core/Yoakke.Lexer/Regexes.cs
@@ -41,7 +41,24 @@ namespace Yoakke.Lexer
         ///
         /// Note that this CANNOT represent all IEEE-754 floating point values, as special values such as infinity or NaN are not supported.
         /// </remarks>
-        public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)-?[0-9]+)?";
+        /// <seealso cref="IeeeFloatLiteral(string, string)"/>
+        public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?";
+
+        /// <summary>
+        /// IEEE-754 floating point real number with an optional fractionary part, scientific notation and digit separator.
+        /// </summary>
+        /// <remarks>
+        /// Accepts both decimal numbers that are integers and numbers that have a fractionary part (e.g. both <c>2</c> and <c>2.0</c> are valid).
+        /// If the whole part is zero, it may be omitted (<c>.12</c> means <c>0.12</c>).
+        /// A leading sign (<c>+</c> or <c>-</c>) may be indicated, but only if the whole part is provided and begins with a number.
+        /// Digits may be separated with <c>_</c>, but this symbol may not appear in the first position (<c>1_234.1</c> means <c>1234.1</c>).
+        /// Scientific notation is supported by appending <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
+        /// </remarks>
+        /// <param name="infinityLiteral">The keyword to represent the infinity value. Positive and negative infinity are disambiguated with a leading sign.</param>
+        /// <param name="nanLiteral">The keyword to represent the NaN (Not a Number) value.</param>
+        /// <returns>A regular expression capable of accepting representations for all values of IEEE-754 floating point numbers with the provided parameters.</returns>
+        public static string IeeeFloatLiteral(string infinityLiteral = "infinity", string nanLiteral = "NaN") =>
+            $"((([0-9]*.)|([+-]?[0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?)|([+-]?{infinityLiteral})|({nanLiteral})";
 
         /// <summary>
         /// A single-line string.

--- a/Sources/Core/Yoakke.Lexer/Regexes.cs
+++ b/Sources/Core/Yoakke.Lexer/Regexes.cs
@@ -30,6 +30,19 @@ namespace Yoakke.Lexer
         public const string HexLiteral = "0x[0-9a-fA-F]+";
 
         /// <summary>
+        /// Decimal number with an optional fractionary part and optional scientific notation.
+        /// </summary>
+        /// <remarks>
+        /// Accepts both decimal numbers that are integers and numbers that have a fractionary part (e.g. both <c>2</c> and <c>2.0</c> are valid).
+        /// If the whole part is zero, it may be omitted (<c>.12</c> means <c>0.12</c>).
+        /// This does not capture the leading sign (<c>+</c> or <c>-</c>), which must be handled separately.
+        /// Scientific notation is supported by writting <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
+        ///
+        /// Note that this CANNOT represent all IEEE-754 floating point values, as special values such as infinity or NaN are not supported.
+        /// </remarks>
+        public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)-?[0-9]+)?";
+
+        /// <summary>
         /// A single-line string.
         /// </summary>
         public const string StringLiteral = @"""((\\[^\n\r])|[^\r\n\\""])*""";

--- a/Sources/Core/Yoakke.Lexer/Regexes.cs
+++ b/Sources/Core/Yoakke.Lexer/Regexes.cs
@@ -30,13 +30,14 @@ namespace Yoakke.Lexer
         public const string HexLiteral = "0x[0-9a-fA-F]+";
 
         /// <summary>
-        /// Decimal number with an optional fractionary part and optional scientific notation.
+        /// Real number with an optional fractionary part, scientific notation and digit separator.
         /// </summary>
         /// <remarks>
         /// Accepts both decimal numbers that are integers and numbers that have a fractionary part (e.g. both <c>2</c> and <c>2.0</c> are valid).
         /// If the whole part is zero, it may be omitted (<c>.12</c> means <c>0.12</c>).
         /// This does not capture the leading sign (<c>+</c> or <c>-</c>), which must be handled separately.
-        /// Scientific notation is supported by writting <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
+        /// Digits may be separated with <c>_</c>, but this symbol may not appear in the first position (<c>1_234.1</c> means <c>1234.1</c>).
+        /// Scientific notation is supported by appending <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
         ///
         /// Note that this CANNOT represent all IEEE-754 floating point values, as special values such as infinity or NaN are not supported.
         /// </remarks>


### PR DESCRIPTION
The class `Yoakke.Lexer.Regexes` has many utility regexes for many kinds of common literals, but no literals for floating point numbers. This PR adds two new regexes,:

- A generic real number literal that does not accept a leading sign (so for example the user-defined unary `-` works in a more predictable way in situations like `-123.abs()`),
- A regex for values of IEEE-754 floating point numbers of any precision.

Both support the following features:
- Number separators with `_`, so `1_234.1` can be used to represent `1234.1`. This idea appears in many languages, such as Rust.
- Scientific notation with `e` or `E`, followed by an integer with optional leading sign.