### PR TITLE
Made lexer and parser nest arbitrarily

### DIFF
--- a/Sources/Core/Yoakke.Lexer.Generator/LexerSourceGenerator.cs
+++ b/Sources/Core/Yoakke.Lexer.Generator/LexerSourceGenerator.cs
@@ -141,9 +141,9 @@ namespace Yoakke.Lexer.Generator
 
                     var matchCondition = (lower, upper) switch
                     {
-                        (char l, char h) => $"case char ch when '{Escape(l)}' <= currentChar && currentChar <= '{Escape(h)}':",
-                        (char l, null) => $"case char ch when '{Escape(l)}' <= currentChar:",
-                        (null, char h) => $"case char ch when currentChar <= '{Escape(h)}':",
+                        (char l, char h) => $"case >= '{Escape(l)}' and <= '{Escape(h)}':",
+                        (char l, null) => $"case >= '{Escape(l)}':",
+                        (null, char h) => $"case <= '{Escape(h)}':",
                         (null, null) => "case char ch:",
                     };
                     transitionTable.AppendLine(matchCondition);

--- a/Sources/Core/Yoakke.SourceGenerator.Common/Diagnostics.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/Diagnostics.cs
@@ -46,6 +46,17 @@ namespace Yoakke.SourceGenerator.Common
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        /// <summary>
+        /// Descriptor for a <see cref="Diagnostic"/> when a symbol is required to accept external declarations, but it does not.
+        /// </summary>
+        public static readonly DiagnosticDescriptor SymbolDoesNotAcceptExternalDeclarations = new(
+            id: "YKGEN004",
+            title: "Symbol is not partial or a namespace",
+            messageFormat: "The symbol {0} is not partial or a namespace",
+            category: "Yoakke.Generator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
 #pragma warning restore RS2008 // Enable analyzer release tracking
     }
 }

--- a/Sources/Core/Yoakke.SourceGenerator.Common/Diagnostics.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/Diagnostics.cs
@@ -51,8 +51,8 @@ namespace Yoakke.SourceGenerator.Common
         /// </summary>
         public static readonly DiagnosticDescriptor SymbolDoesNotAcceptExternalDeclarations = new(
             id: "YKGEN004",
-            title: "Symbol is not partial or a namespace",
-            messageFormat: "The symbol {0} is not partial or a namespace",
+            title: "Symbol is not surrounded by partial types or a namespaces",
+            messageFormat: "The symbol {0} is not surrounded by partial types or a namespaces",
             category: "Yoakke.Generator",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/Sources/Core/Yoakke.SourceGenerator.Common/GeneratorBase.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/GeneratorBase.cs
@@ -143,6 +143,22 @@ namespace Yoakke.SourceGenerator.Common
         }
 
         /// <summary>
+        /// Requires an <see cref="ITypeSymbol"/> to be declared partial.
+        /// If it is not, a <see cref="Diagnostic"/> error is raised.
+        /// </summary>
+        /// <param name="symbol">The <see cref="ITypeSymbol"/> to check.</param>
+        /// <returns>True, if <paramref name="symbol"/> is partial.</returns>
+        protected bool RequirePartial(ITypeSymbol symbol)
+        {
+            if (!symbol.IsPartial())
+            {
+                this.Report(Diagnostics.TypeDefinitionIsNotPartial, symbol.Name);
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Requires a <see cref="ISymbol"/> not to be a nested type.
         /// If it is a nested type, a <see cref="Diagnostic"/> error is raised.
         /// </summary>
@@ -153,6 +169,23 @@ namespace Yoakke.SourceGenerator.Common
             if (symbol.IsNested())
             {
                 this.Report(Diagnostics.SymbolIsNested, symbol.Locations.First(), symbol.Name);
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Requires a <see cref="ISymbol"/> to be able to accept declarations inside from external sources.
+        /// This can mean that the symbol is a namespace or partial.
+        /// If it does not, a <see cref="Diagnostic"/> error is raised.
+        /// </summary>
+        /// <param name="symbol">The <see cref="ISymbol"/> to check.</param>
+        /// <returns>True, if <paramref name="symbol"/> accepts declarations inside from external sources.</returns>
+        protected bool RequireDeclarableInside(ISymbol symbol)
+        {
+            if (!symbol.CanDeclareInsideExternally())
+            {
+                this.Report(Diagnostics.SymbolDoesNotAcceptExternalDeclarations, symbol.Locations.First(), symbol.Name);
                 return false;
             }
             return true;

--- a/Sources/Core/Yoakke.SourceGenerator.Common/GeneratorBase.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/GeneratorBase.cs
@@ -152,7 +152,7 @@ namespace Yoakke.SourceGenerator.Common
         {
             if (!symbol.IsPartial())
             {
-                this.Report(Diagnostics.TypeDefinitionIsNotPartial, symbol.Name);
+                this.Report(Diagnostics.TypeDefinitionIsNotPartial, symbol.Locations.First(), symbol.Name);
                 return false;
             }
             return true;

--- a/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
@@ -4,9 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Yoakke.SourceGenerator.Common.RoslynExtensions
 {
@@ -29,12 +32,66 @@ namespace Yoakke.SourceGenerator.Common.RoslynExtensions
         };
 
         /// <summary>
+        /// Checks, if a <see cref="ITypeSymbol"/>s declaration is partial.
+        /// </summary>
+        /// <param name="symbol">The <see cref="ITypeSymbol"/> to check.</param>
+        /// <returns>True, if <paramref name="symbol"/> is declared partial.</returns>
+        public static bool IsPartial(this ITypeSymbol symbol) => symbol.DeclaringSyntaxReferences
+            .Any(syntaxRef => syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl && typeDecl.IsPartial());
+
+        /// <summary>
         /// Checks, if a <see cref="ISymbol"/> is a nested type.
         /// </summary>
         /// <param name="symbol">The <see cref="ISymbol"/> to check.</param>
         /// <returns>True, if <paramref name="symbol"/> is a nested type.</returns>
-        public static bool IsNested(this ISymbol symbol) =>
-            !SymbolEqualityComparer.Default.Equals(symbol.ContainingSymbol, symbol.ContainingNamespace);
+        public static bool IsNested(this ISymbol symbol) => symbol.ContainingSymbol is ITypeSymbol;
+
+        /// <summary>
+        /// Checks, if an <see cref="ISymbol"/> can accept declarations from other source files.
+        /// This usually means that the symbol is a namespace or is in partial type definitions.
+        /// </summary>
+        /// <param name="symbol">The <see cref="ISymbol"/> to check.</param>
+        /// <returns>True, if <paramref name="symbol"/> accepts declarations inside it from other sources.</returns>
+        public static bool CanDeclareInsideExternally(this ISymbol symbol)
+        {
+            if (symbol is null || symbol is INamespaceSymbol) return true;
+            if (symbol is ITypeSymbol type) return type.IsPartial() && (type.ContainingSymbol?.CanDeclareInsideExternally() ?? true);
+            return false;
+        }
+
+        /// <summary>
+        /// Builds up code that is required to define something inside an <see cref="ISymbol"/>.
+        /// </summary>
+        /// <param name="symbol">The <see cref="ISymbol"/> to build up the code for.</param>
+        /// <returns>A pair of prefix and suffix text, that is enough to write declarations inside <paramref name="symbol"/>.</returns>
+        public static (string Prefix, string Suffix) DeclareInsideExternally(this ISymbol symbol)
+        {
+            var prefixBuilder = new StringBuilder();
+            var suffixBuilder = new StringBuilder();
+
+            void DeclareInsideExternallyRec(ISymbol symbol)
+            {
+                if (symbol is null) return;
+                if (symbol is ITypeSymbol type)
+                {
+                    Debug.Assert(type.IsPartial(), "Type declaration must be partial");
+                    DeclareInsideExternallyRec(symbol.ContainingSymbol);
+                    prefixBuilder!.AppendLine($"partial {type.GetTypeKindName()} {{");
+                    suffixBuilder!.AppendLine("}");
+                    return;
+                }
+                if (symbol is INamespaceSymbol ns)
+                {
+                    prefixBuilder!.AppendLine($"namespace {ns.ToDisplayString()} {{");
+                    suffixBuilder!.AppendLine("}");
+                    return;
+                }
+                throw new InvalidOperationException();
+            }
+
+            DeclareInsideExternallyRec(symbol);
+            return (prefixBuilder.ToString(), suffixBuilder.ToString());
+        }
 
         /// <summary>
         /// Checks, if a <see cref="ISymbol"/> implements a given interface.

--- a/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
@@ -74,9 +74,9 @@ namespace Yoakke.SourceGenerator.Common.RoslynExtensions
                 if (symbol is null) return;
                 if (symbol is ITypeSymbol type)
                 {
-                    Debug.Assert(type.IsPartial(), "Type declaration must be partial");
+                    if (!type.IsPartial()) throw new InvalidOperationException("Non-partial type nesting");
                     DeclareInsideExternallyRec(symbol.ContainingSymbol);
-                    prefixBuilder!.AppendLine($"partial {type.GetTypeKindName()} {{");
+                    prefixBuilder!.AppendLine($"partial {type.GetTypeKindName()} {type.Name} {{");
                     suffixBuilder!.AppendLine("}");
                     return;
                 }
@@ -86,7 +86,7 @@ namespace Yoakke.SourceGenerator.Common.RoslynExtensions
                     suffixBuilder!.AppendLine("}");
                     return;
                 }
-                throw new InvalidOperationException();
+                throw new InvalidOperationException("Unknown symbol to nest in");
             }
 
             DeclareInsideExternallyRec(symbol);

--- a/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
+++ b/Sources/Core/Yoakke.SourceGenerator.Common/RoslynExtensions/SymbolExtensions.cs
@@ -20,6 +20,7 @@ namespace Yoakke.SourceGenerator.Common.RoslynExtensions
     {
         /// <summary>
         /// Retrieves the type kind of a <see cref="ISymbol"/> that can be used in codegen.
+        /// This can be 'class', 'struct' or 'record'.
         /// </summary>
         /// <param name="symbol">The <see cref="ISymbol"/> to get the kind of.</param>
         /// <returns>The code-friendly name of the type kind.</returns>

--- a/Sources/Tests/Yoakke.Lexer.Tests/LexerGeneratorTests.cs
+++ b/Sources/Tests/Yoakke.Lexer.Tests/LexerGeneratorTests.cs
@@ -9,7 +9,7 @@ using IgnoreAttribute = Yoakke.Lexer.Attributes.IgnoreAttribute;
 namespace Yoakke.Lexer.Tests
 {
     [TestClass]
-    public class LexerGeneratorTests : TestBase<LexerGeneratorTests.TokenType>
+    public partial class LexerGeneratorTests : TestBase<LexerGeneratorTests.TokenType>
     {
         [Lexer("Lexer")]
         public enum TokenType

--- a/Sources/Tests/Yoakke.Parser.Tests/ExpressionParserTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/ExpressionParserTests.cs
@@ -39,7 +39,7 @@ namespace Yoakke.Parser.Tests
     }
 
     [TestClass]
-    public class ExpressionParserTests
+    public partial class ExpressionParserTests
     {
         [Lexer("ExprLexer")]
         public enum TokenType

--- a/Sources/Tests/Yoakke.Parser.Tests/ExpressionParserTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/ExpressionParserTests.cs
@@ -11,38 +11,11 @@ using IgnoreAttribute = Yoakke.Lexer.Attributes.IgnoreAttribute;
 
 namespace Yoakke.Parser.Tests
 {
-    [Parser(typeof(ExpressionParserTests.TokenType))]
-    internal partial class ExprParser
-    {
-        [Rule("top_expression : expression End")]
-        private static int TopLevel(int n, IToken _) => n;
-
-        [Right("^")]
-        [Left("*", "/")]
-        [Left("+", "-")]
-        [Rule("expression")]
-        private static int Op(int left, IToken op, int right) => op.Text switch
-        {
-            "+" => left + right,
-            "-" => left - right,
-            "*" => left * right,
-            "/" => left / right,
-            "^" => (int)Math.Pow(left, right),
-            _ => throw new InvalidOperationException(),
-        };
-
-        [Rule("expression : '(' expression ')'")]
-        private static int Grouping(IToken _1, int n, IToken _2) => n;
-
-        [Rule("expression : Number")]
-        private static int Number(IToken tok) => int.Parse(tok.Text);
-    }
-
     [TestClass]
     public partial class ExpressionParserTests
     {
-        [Lexer("ExprLexer")]
-        public enum TokenType
+        [Lexer("Lexer")]
+        internal enum TokenType
         {
             [End] End,
             [Error] Error,
@@ -58,7 +31,34 @@ namespace Yoakke.Parser.Tests
             [Token(")")] Rparen,
         }
 
-        private static int Eval(string s) => new ExprParser(new ExprLexer(s)).ParseTopExpression().Ok.Value;
+        [Parser(typeof(TokenType))]
+        internal partial class Parser
+        {
+            [Rule("top_expression : expression End")]
+            private static int TopLevel(int n, IToken _) => n;
+
+            [Right("^")]
+            [Left("*", "/")]
+            [Left("+", "-")]
+            [Rule("expression")]
+            private static int Op(int left, IToken op, int right) => op.Text switch
+            {
+                "+" => left + right,
+                "-" => left - right,
+                "*" => left * right,
+                "/" => left / right,
+                "^" => (int)Math.Pow(left, right),
+                _ => throw new InvalidOperationException(),
+            };
+
+            [Rule("expression : '(' expression ')'")]
+            private static int Grouping(IToken _1, int n, IToken _2) => n;
+
+            [Rule("expression : Number")]
+            private static int Number(IToken tok) => int.Parse(tok.Text);
+        }
+
+        private static int Eval(string s) => new Parser(new Lexer(s)).ParseTopExpression().Ok.Value;
 
         [TestMethod]
         public void Tests()

--- a/Sources/Tests/Yoakke.Parser.Tests/Issue59Tests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/Issue59Tests.cs
@@ -16,32 +16,12 @@ using Token = Yoakke.Lexer.IToken<Yoakke.Parser.Tests.Issue59Tests.TokenType>;
 
 namespace Yoakke.Parser.Tests
 {
-    /*
-     https://github.com/LanguageDev/Yoakke/issues/59
-     */
-
-    [Parser(typeof(Issue59Tests.TokenType))]
-    internal partial class Issue59Parser
-    {
-        [Rule("expression : call")]
-        [Rule("call : primary")]
-        public static string Identity(string expression) => expression;
-
-        [Rule("call : call '(' ')'")]
-        public static string FunctionCall(string callee, Token _open, Token _close) => $"({callee}())";
-
-        [Rule("call : call '.' Identifier")]
-        public static string MemberAccess(string @object, Token _dot, Token identifier) => $"({@object}.{identifier.Text})";
-
-        [Rule("primary : Identifier")]
-        public static string Primary(Token atom) => atom.Text;
-    }
-
+    // https://github.com/LanguageDev/Yoakke/issues/59
     [TestClass]
     public partial class Issue59Tests
     {
-        [Lexer("LeftRecursionAltsIssueLexer")]
-        public enum TokenType
+        [Lexer("Lexer")]
+        internal enum TokenType
         {
             [End] End,
             [Error] Error,
@@ -54,8 +34,25 @@ namespace Yoakke.Parser.Tests
             [Token(")")] CloseParen,
         }
 
+        [Parser(typeof(TokenType))]
+        internal partial class Parser
+        {
+            [Rule("expression : call")]
+            [Rule("call : primary")]
+            public static string Identity(string expression) => expression;
+
+            [Rule("call : call '(' ')'")]
+            public static string FunctionCall(string callee, Token _open, Token _close) => $"({callee}())";
+
+            [Rule("call : call '.' Identifier")]
+            public static string MemberAccess(string @object, Token _dot, Token identifier) => $"({@object}.{identifier.Text})";
+
+            [Rule("primary : Identifier")]
+            public static string Primary(Token atom) => atom.Text;
+        }
+
         private static string Parse(string source) =>
-           new Issue59Parser(new LeftRecursionAltsIssueLexer(source)).ParseCall().Ok.Value;
+           new Parser(new Lexer(source)).ParseCall().Ok.Value;
 
         [TestMethod]
         public void TestPrimary() => Assert.AreEqual("x", Parse("x"));

--- a/Sources/Tests/Yoakke.Parser.Tests/Issue59Tests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/Issue59Tests.cs
@@ -38,7 +38,7 @@ namespace Yoakke.Parser.Tests
     }
 
     [TestClass]
-    public class Issue59Tests
+    public partial class Issue59Tests
     {
         [Lexer("LeftRecursionAltsIssueLexer")]
         public enum TokenType

--- a/Sources/Tests/Yoakke.Parser.Tests/LeftRecursionTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/LeftRecursionTests.cs
@@ -16,22 +16,11 @@ namespace Yoakke.Parser.Tests
 
      Proposal: When we detect direct left-recursion that we can't resolve, error out and suggest that it's a possible typo
      */
-
-    [Parser(typeof(LeftRecursionTests.TokenType))]
-    internal partial class LeftRecursionParser
-    {
-        [Rule("grouping : grouping Identifier")]
-        private static string Group(string group, IToken next) => $"({group}, {next.Text})";
-
-        [Rule("grouping: Identifier")]
-        private static string Ident(IToken t) => t.Text;
-    }
-
     [TestClass]
     public partial class LeftRecursionTests
     {
-        [Lexer("LeftRecursionLexer")]
-        public enum TokenType
+        [Lexer("Lexer")]
+        internal enum TokenType
         {
             [End] End,
             [Error] Error,
@@ -40,8 +29,18 @@ namespace Yoakke.Parser.Tests
             [Regex(Regexes.Identifier)] Identifier,
         }
 
+        [Parser(typeof(TokenType))]
+        internal partial class Parser
+        {
+            [Rule("grouping : grouping Identifier")]
+            private static string Group(string group, IToken next) => $"({group}, {next.Text})";
+
+            [Rule("grouping: Identifier")]
+            private static string Ident(IToken t) => t.Text;
+        }
+
         private static string Parse(string source) =>
-            new LeftRecursionParser(new LeftRecursionLexer(source)).ParseGrouping().Ok.Value;
+            new Parser(new Lexer(source)).ParseGrouping().Ok.Value;
 
         [TestMethod]
         public void TestOne() => Assert.AreEqual("a", Parse("a"));

--- a/Sources/Tests/Yoakke.Parser.Tests/LeftRecursionTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/LeftRecursionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 Yoakke.
+// Copyright (c) 2021 Yoakke.
 // Licensed under the Apache License, Version 2.0.
 // Source repository: https://github.com/LanguageDev/Yoakke
 
@@ -28,7 +28,7 @@ namespace Yoakke.Parser.Tests
     }
 
     [TestClass]
-    public class LeftRecursionTests
+    public partial class LeftRecursionTests
     {
         [Lexer("LeftRecursionLexer")]
         public enum TokenType

--- a/Sources/Tests/Yoakke.Parser.Tests/PunctuatedTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/PunctuatedTests.cs
@@ -14,23 +14,11 @@ using Token = Yoakke.Lexer.IToken<Yoakke.Parser.Tests.PunctuatedTests.TokenType>
 
 namespace Yoakke.Parser.Tests
 {
-    [Parser(typeof(PunctuatedTests.TokenType))]
-    internal partial class ListParser
-    {
-        [Rule("any0_no_trailing : Lparen (Identifier (',' Identifier)*)? Rparen")]
-        private static List<string> ZeroOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) =>
-            elements.Values.Select(t => t.Text).ToList();
-
-        [Rule("any1_no_trailing : Lparen (Identifier (',' Identifier)*) Rparen")]
-        private static List<string> OneOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) =>
-            elements.Values.Select(t => t.Text).ToList();
-    }
-
     [TestClass]
     public partial class PunctuatedTests
     {
-        [Lexer("ListLexer")]
-        public enum TokenType
+        [Lexer("Lexer")]
+        internal enum TokenType
         {
             [End] End,
             [Error] Error,
@@ -42,9 +30,21 @@ namespace Yoakke.Parser.Tests
             [Regex(Regexes.Identifier)] Identifier,
         }
 
-        private static List<string> Any0NoTrailing(string source) => new ListParser(new ListLexer(source)).ParseAny0NoTrailing().Ok.Value;
+        [Parser(typeof(TokenType))]
+        internal partial class Parser
+        {
+            [Rule("any0_no_trailing : Lparen (Identifier (',' Identifier)*)? Rparen")]
+            private static List<string> ZeroOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) =>
+                elements.Values.Select(t => t.Text).ToList();
 
-        private static List<string> Any1NoTrailing(string source) => new ListParser(new ListLexer(source)).ParseAny1NoTrailing().Ok.Value;
+            [Rule("any1_no_trailing : Lparen (Identifier (',' Identifier)*) Rparen")]
+            private static List<string> OneOrMoreNoTrailing(IToken _lp, Punctuated<Token, Token> elements, IToken _rp) =>
+                elements.Values.Select(t => t.Text).ToList();
+        }
+
+        private static List<string> Any0NoTrailing(string source) => new Parser(new Lexer(source)).ParseAny0NoTrailing().Ok.Value;
+
+        private static List<string> Any1NoTrailing(string source) => new Parser(new Lexer(source)).ParseAny1NoTrailing().Ok.Value;
 
         [TestMethod]
         public void Empty0NoTrailing() => Assert.IsTrue(Any0NoTrailing("()").SequenceEqual(Array.Empty<string>()));

--- a/Sources/Tests/Yoakke.Parser.Tests/PunctuatedTests.cs
+++ b/Sources/Tests/Yoakke.Parser.Tests/PunctuatedTests.cs
@@ -27,7 +27,7 @@ namespace Yoakke.Parser.Tests
     }
 
     [TestClass]
-    public class PunctuatedTests
+    public partial class PunctuatedTests
     {
         [Lexer("ListLexer")]
         public enum TokenType


### PR DESCRIPTION
Lexer and Parser are properly generated in multiply nested types. Moved tests accordingly.

Closes #63 
