### PR TITLE
Fix lexer regexes for real numbers

### DIFF
--- a/Sources/Core/Yoakke.Lexer/Regexes.cs
+++ b/Sources/Core/Yoakke.Lexer/Regexes.cs
@@ -42,7 +42,7 @@ namespace Yoakke.Lexer
         /// Note that this CANNOT represent all IEEE-754 floating point values, as special values such as infinity or NaN are not supported.
         /// </remarks>
         /// <seealso cref="IeeeFloatLiteral"/>
-        public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?";
+        public const string RealNumberLiteral = "(([0-9]*.)|([0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)(+|-)?[0-9]+)?";
 
         /// <summary>
         /// IEEE-754 floating point real number with an optional fractionary part, scientific notation and digit separator.
@@ -55,7 +55,7 @@ namespace Yoakke.Lexer
         /// Scientific notation is supported by appending <c>e</c> or <c>E</c> and then using an integer exponent, which may be optionally negative.
         /// Special cases <c>infinity</c> and <c>NaN</c> are supported, where positive and negative infinity are disambiguated using a leading sign.
         /// </remarks>
-        public const string IeeeFloatLiteral = "((([0-9]*.)|([+-]?[0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)[+-]?[0-9]+)?)|([+-]?infinity)|(NaN)";
+        public const string IeeeFloatLiteral = "((([0-9]*.)|((+|-)?[0-9]+[0-9_]*.))?[0-9]+[0-9_]*((e|E)(+|-)?[0-9]+)?)|((+|-)?infinity)|(NaN)";
 
         /// <summary>
         /// A single-line string.


### PR DESCRIPTION
Hotfixes #82 provisionally until contributors can find a more permanent solution.

The current lexer regexes for IEEE floating point literals and real numbers available as constants in `Yoakke.Lexer.Regexes` cause the regex engine to throw an error as detailed in #82, because the set syntax `[+-]` has been used lazily instead of the more natural alternative `(+|-)`. 

Even though both alternatives would result in the same optimized DFA if the error didn't manifest, it is important to keep the regex readable as these constants will be seen by many users of Yoakke. Hence, this change also achieves to obtain a slight boost in readability as a side effect.