### PR TITLE
Fixed potential massive slowdown with lexer generator

### DIFF
--- a/Sources/Core/Yoakke.Lexer.Generator/LexerSourceGenerator.cs
+++ b/Sources/Core/Yoakke.Lexer.Generator/LexerSourceGenerator.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Generic.Polyfill;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -253,8 +254,16 @@ end_loop:
         private (IDenseDfa<StateSet<int>, char> Dfa, Dictionary<StateSet<int>, TokenDescription> StateToToken)?
             BuildDfa(LexerDescription description)
         {
-            var stateCount = 0;
-            int MakeState() => stateCount++;
+            var rnd = new Random();
+            var occupiedStates = new HashSet<int>();
+            int MakeState()
+            {
+                while (true)
+                {
+                    var s = rnd.Next();
+                    if (occupiedStates.Add(s)) return s;
+                }
+            }
 
             // Store which token corresponds to which end state
             var tokenToNfaState = new Dictionary<TokenDescription, int>();


### PR DESCRIPTION
The lexer generator showed a massive slowdown around determinization, when C keywords were recognized with it. This is because - as it turns out - nearby states in the `StateSet`s unified, meaning they were hashed with XOR, yielding values like `1`, `2`, `3` very frequently. The slowdown was thereby caused by the hash-set search degraded to a linear search.

This PR fixes this by assigning random positive integer values as the state ID, when generating the NFA instead of sequential numbers.

Closes #114 