### PR TITLE
Speedup merging of parse error

### DIFF
--- a/Sources/SynKit/Libraries/Parser/ParseErrorElementDictionary.cs
+++ b/Sources/SynKit/Libraries/Parser/ParseErrorElementDictionary.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2021-2022 Yoakke.
+// Licensed under the Apache License, Version 2.0.
+// Source repository: https://github.com/LanguageDev/Yoakke
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Generic.Polyfill;
+using System.Linq;
+
+namespace Yoakke.SynKit.Parser;
+
+internal class ParseErrorElementDictionary : IReadOnlyDictionary<string, ParseErrorElement>
+{
+    private string? firstKey;
+    private ParseErrorElement? firstItem;
+    private Dictionary<string, ParseErrorElement>? elements;
+
+    private ParseErrorElementDictionary()
+    {
+    }
+
+    private ParseErrorElementDictionary(Dictionary<string, ParseErrorElement> elements)
+    {
+        this.elements = elements;
+    }
+
+    public ParseErrorElementDictionary(string key, ParseErrorElement value)
+    {
+        this.firstKey = key;
+        this.firstItem = value;
+    }
+
+    public ParseErrorElement this[string key] => this.firstKey is null
+        ? this.elements is null
+            ? throw new KeyNotFoundException($"The key {key} was not found in the dictionary")
+            : this.elements[key]
+        : this.firstItem!;
+
+    public IEnumerable<string> Keys => this.firstKey is null ? this.elements!.Keys : new[] { this.firstKey };
+
+    public IEnumerable<ParseErrorElement> Values => this.firstKey is null ? this.elements!.Values : new[] { this.firstItem! };
+
+    public int Count => this.firstKey is null ? this.elements is null ? 0 : this.elements.Count : 1;
+
+    public bool ContainsKey(string key) => this.firstKey is null ? this.elements is null ? false : this.elements.ContainsKey(key) : this.firstKey == key;
+    public IEnumerator<KeyValuePair<string, ParseErrorElement>> GetEnumerator() => throw new NotImplementedException();
+    public bool TryGetValue(string key, out ParseErrorElement value) => throw new NotImplementedException();
+    IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+    public ParseErrorElementDictionary Merge(ParseErrorElementDictionary other)
+    {
+        if (this.elements is null)
+        {
+            if (other.elements is null)
+            {
+                if (this.firstKey == other.firstKey)
+                {
+                    var newExpected = other.firstItem!.Expected.ToHashSet();
+                    newExpected.UnionWith(this.firstItem!.Expected);
+                    return new(other.firstKey!, new (newExpected, this.firstItem.Context));
+                }
+                else
+                {
+                    return new(new Dictionary<string, ParseErrorElement>
+                    {
+                        { this.firstKey!, this.firstItem! },
+                        { other.firstKey!, other.firstItem! },
+                    });
+                }
+            }
+            else
+            {
+                return new(new (other.elements));
+            }
+        }
+
+        var elements = this.elements.Values.ToDictionary(e => e.Context, e => new ParseErrorElement(e.Expected.ToHashSet(), e.Context));
+        foreach (var element in other.Values)
+        {
+            if (elements.TryGetValue(element.Context, out var part))
+            {
+                foreach (var e in element.Expected) part.Expected.Add(e);
+            }
+            else
+            {
+                part = new(element.Expected.ToHashSet(), element.Context);
+                elements.Add(element.Context, part);
+            }
+        }
+
+        return new (elements);
+    }
+}


### PR DESCRIPTION
I don't want to use full blown Dictionary since most of the time we have only one item in it. So shortcircuit things for simple cases make code faster.

## Before

| Method                 | Mean           | Error         | StdDev        | Median         |
|----------------------- |---------------:|--------------:|--------------:|---------------:|
| ExpressionParser       | 6,213,672.3 us | 201,067.50 us | 592,852.12 us | 5,941,961.0 us |
| ManualExpressionParser |    18,644.7 us |     263.30 us |     246.29 us |    18,598.4 us |
| Lex                    |       946.6 us |       5.51 us |       5.16 us |       947.2 us |

## After

| Method                 | Mean           | Error        | StdDev      |
|----------------------- |---------------:|-------------:|------------:|
| ExpressionParser       | 3,326,861.3 us | 12,140.53 us | 9,478.53 us |
| ManualExpressionParser |    13,073.6 us |    111.79 us |   104.56 us |
| Lex                    |       945.7 us |      9.11 us |     8.52 us |